### PR TITLE
Document Optimus conventions and first-class testing posture

### DIFF
--- a/docs/project-notes.md
+++ b/docs/project-notes.md
@@ -3,7 +3,7 @@
 ## Notes
 
 - This is a reboot of the Courtview project at `aaa/courtview`. Courtview is historical reference, not a dependency — schema is derived from requirements, not ported.
-- This project will utilize the Optimus template at `aaa/optimus-base` as its starting point. MPI/Optimus references are scrubbed in Phase 0.
+- This project will utilize the Optimus template at `aaa/optimus-base` as its starting point. **MPI-specific** references are scrubbed in Phase 0; **Optimus conventions** (model/concern/controller/route patterns, enum modules, Ransack, Notification/Loggable/Archivable concerns, member/collection exports, Claude configuration) are preserved and followed going forward. See `docs/spec.md` §7 Phase 0 for the preserve/scrub list.
 - This project is a personal and public project locally at `aaa/baseline` and on the `wrburgess/baseline` GitHub repo. "Public" means the source code is open; the deployed app is **always behind authentication** — no unauthenticated surfaces.
 - Deployed at `baseline.kc.tennis`.
 - Full spec: [`docs/spec.md`](./spec.md).
@@ -146,6 +146,9 @@
 - **Schema is derived, not ported.** Fresh data model based on requirements + USTA domain realities (flights, sub-flights, tri-level, combo formats, post-season levels).
 - **No pre-emptive features.** v0 ships the smallest viable scouting tool. v1 ideas stay in the deferred list.
 - **Two ship milestones:** dogfood (end of Phase 6), invite-a-captain (end of Phase 11).
+- **Follow Optimus conventions.** Models, concerns, controllers, routes, and enum modules follow the patterns established in the Optimus template. Ransack is the standard for index-page search and filtering. The `Notification`, `Loggable`, and `Archivable` concerns apply to every data model, as do the member- and collection-export patterns. Established Rails and Optimus conventions exist specifically to keep AC from diverging into stray paths of development.
+- **Testing is first-class from v0 onward.** Every code change — new file, edit, bug fix, refactor — must be accompanied by a test decision: either a new spec is written to improve coverage, or existing specs are adjusted to reflect the change. No code lands without this determination being made and noted in the PR. Model specs, request specs for controllers, and Capybara feature specs for user-facing interfaces are all required; factories are efficient (minimal attributes, traits over duplication, `build_stubbed` where possible). See `docs/spec.md` §8 for details.
+- **Preserve Optimus Claude configuration.** `CLAUDE.md`, `AGENT.md`, `.claude/` settings, hooks, and harness config from Optimus carry over into Baseline (with MPI-specific references rewritten). Don't re-derive what Optimus already optimized.
 
 ### Approach
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -432,9 +432,21 @@ Full-design, not default scaffolds:
 
 Each phase has a dedicated issue in the [`Baseline Setup`](https://github.com/users/wrburgess/projects/2) project with problem, proposed solution, locked decisions, acceptance criteria, and open questions. Reference phase issues from commits and PRs.
 
-**Phase 0** — Import Optimus template + scrub MPI/Optimus references + deploy "Hello World" to `baseline.kc.tennis` via Kamal. CI green before any app code exists.
+**Phase 0** — Import Optimus template + scrub MPI references + deploy "Hello World" to `baseline.kc.tennis` via Kamal. CI green before any app code exists.
 
-**Phase 1** — Schema foundation. Fresh Baseline schema derived from §3. Models, validations, factories. Seed a minimum of one league + a few players to exercise the schema. No Courtview migration (decommissioned).
+What is **scrubbed**: MPI-specific domain names, models, data, copy, branding, fixtures, seeds, and any MPI references in config, README, or comments.
+
+What is **preserved from Optimus** (renamed to Baseline where appropriate, but structurally intact):
+- **Model / concern / controller / route patterns** — follow Optimus conventions for namespacing, resource routing, controller inheritance, and concern composition. Do not diverge into stray patterns.
+- **Shared concerns** — `Notification`, `Loggable`, `Archivable` concerns and their accompanying migrations, helpers, and specs.
+- **Member and collection export patterns** — the Optimus data-model export convention (CSV/JSON member exports and collection exports) is the standard for all Baseline data models.
+- **Enumeration module pattern** — enums are declared via dedicated modules (e.g., `Enums::MatchFormat`, `Enums::ImportKind`), not inline `enum :foo, { ... }` calls scattered through models. Every enum listed in §3 uses this pattern.
+- **Ransack** as the search/filter standard on every index page (admin and public).
+- **Claude Code configuration** — `CLAUDE.md`, `AGENT.md`, `.claude/` settings, hooks, and any Claude Code harness configuration carried over from Optimus, with MPI-specific references rewritten for Baseline.
+- **Authentication + roles scaffolding** — Devise, Pundit, `system_roles`, `system_permissions`, `system_role_permissions` as noted in §3.
+- **Testing harness** — RSpec, FactoryBot, Capybara, shoulda-matchers, timecop, VCR, WebMock configuration, plus any Optimus spec helpers and support files.
+
+**Phase 1** — Schema foundation. Fresh Baseline schema derived from §3. Models, validations, factories, request specs, feature specs. Every data model includes the `Notification`, `Loggable`, and `Archivable` concerns and the member/collection export interface from the Optimus pattern. Enum columns are backed by enum modules (per Phase 0 convention). Seed a minimum of one league + a few players to exercise the schema. No Courtview migration (decommissioned).
 
 **Phase 2** — Wireframes, all pages, no style. Hybrid Claude Design + Claude Code workflow. Per-page: 10-second-answer above the fold, scan pattern, anti-requirements, mobile vs desktop layout. Output: `docs/designs/*.md` IA specs + draft Rails views (unstyled HTML + Bootstrap grid only).
 
@@ -465,15 +477,23 @@ Each phase has a dedicated issue in the [`Baseline Setup`](https://github.com/us
 
 ## 8. Testing Posture
 
-RSpec + Capybara + FactoryBot + shoulda-matchers + timecop + VCR + WebMock.
+**Testing is a first-class concern from v0 onward.** Every code change — new file, edit, bug fix, refactor — must be accompanied by a determination: either a new spec is written to improve coverage, or existing specs are adjusted to reflect the change. This rule applies to all phases, not just Phase 11 polish.
 
-- **Model specs** — validations, key scopes, player resolution algorithm, H2H cache refresh logic. Must-have.
+Stack: RSpec + Capybara + FactoryBot + shoulda-matchers + timecop + VCR + WebMock.
+
+- **Model specs** — validations, associations, scopes, concerns (Notification, Loggable, Archivable), enum modules, business logic (player resolution algorithm, H2H cache refresh logic, member/collection export methods). Every model has a spec.
+- **Request specs** — every controller action. Covers routing, authentication, Pundit authorization, response codes, and response payloads. This is the primary controller coverage layer — not skipped.
+- **Feature specs (Capybara)** — every user-facing interface (dashboard, scouting matrix, player profile, H2H, team profile, team-vs-team, imports flow, admin CRUD surfaces). Cover the golden path plus critical edge cases per page.
 - **Policy specs** — one per Pundit policy. Cheap and critical for a role-locked app.
-- **Service specs** — import pipeline parsers (stub the Claude vision response; test the pipeline around it).
-- **System specs** — one "happy path" per public page. Thin coverage; Capybara is slow, don't over-invest.
-- **Request specs** — skip for v0 unless a specific endpoint has logic outside a policy.
+- **Service / job specs** — import pipeline parsers (stub the Claude vision response; test the pipeline around it), H2H cache refresh job, any background job.
 
-No coverage threshold. Fix bugs by adding a spec, not by targeting a number.
+**Factories (FactoryBot):**
+- One factory per model, mirroring the Optimus pattern.
+- Efficient by default — minimal required attributes, `build` over `create` where possible, `build_stubbed` in unit specs where DB round-trips are unnecessary.
+- Use traits for variants (`:archived`, `:with_grades`, `:captain`, etc.) rather than duplicating factories.
+- Associations declared lazily to avoid cascade creation in unrelated specs.
+
+No coverage threshold. Fix bugs by adding a spec, not by targeting a number. But **no code lands without its corresponding test decision** being made and recorded in the PR.
 
 ---
 


### PR DESCRIPTION
## Summary

Locks in project conventions that were previously unstated or contradicted by the spec, so AC can't drift into stray development patterns.

**`docs/spec.md` §7 Phase 0** — narrow the scrub to MPI-specific references only, and enumerate what is **preserved from Optimus**:
- Model / concern / controller / route patterns
- Shared `Notification`, `Loggable`, `Archivable` concerns
- Member- and collection-export patterns
- Enumeration module pattern (e.g., `Enums::MatchFormat`)
- Ransack on every index page
- `CLAUDE.md`, `AGENT.md`, `.claude/` and Claude Code harness configuration
- Devise / Pundit / roles scaffolding
- RSpec / Capybara / FactoryBot testing harness

**`docs/spec.md` §7 Phase 1** — schema phase now explicitly requires every data model to include the three concerns + export interface, with enums backed by enum modules.

**`docs/spec.md` §8 Testing Posture** — rewritten:
- Testing is first-class from v0 onward (not Phase 11 polish).
- Every code change requires a test decision: new spec written, or existing specs adjusted.
- Request specs are the primary controller coverage layer (was "skip for v0").
- Capybara feature specs cover every user-facing interface (was "thin coverage, don't over-invest").
- Factories: one per model, efficient by default, traits over duplication, `build_stubbed` where possible.

**`docs/project-notes.md` Notes + Expectations** — adds three expectations mirroring the spec: Follow Optimus conventions, Testing is first-class from v0, Preserve Optimus Claude configuration.

## Test plan

Docs-only change; no code paths affected.

- [x] `docs/spec.md` §7 Phase 0 preserve/scrub list reads as intended
- [x] `docs/spec.md` §8 Testing Posture no longer says "skip request specs" or "thin Capybara coverage"
- [x] `docs/project-notes.md` Expectations section references the new conventions and links to spec §7/§8
- [ ] Reviewer confirms the preserve list matches the actual Optimus template (concern names, enum module namespace, export method signatures) — adjust wording here if Optimus uses different names

https://claude.ai/code/session_01FWVHjvBcwAzMKs783ACME2