### PR TITLE
chore: Update Ruby gems (2026-04-20)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,14 @@ gem "rails", "8.1.3"
 # gem install bundler
 
 gem "awesome_print", "1.9.2"
-gem "blazer", "3.3.0"
+gem "blazer", "3.4.0"
 gem "bootsnap", "1.23.0", require: false
 gem "caxlsx_rails", "0.7.1"
 gem "cssbundling-rails", "1.4.3"
 gem "csv", "3.3.5"
 gem "devise", "5.0.3"
 gem "foreman", "0.90.0"
-gem "good_job", "4.18.1"
+gem "good_job", "4.18.2"
 gem "image_processing", "1.14.0"
 gem "importmap-rails", "2.2.3"
 gem "jbuilder", "2.14.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,12 +84,12 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    blazer (3.3.0)
-      activerecord (>= 7.1)
+    blazer (3.4.0)
+      activerecord (>= 7.2)
       chartkick (>= 5)
       csv
-      railties (>= 7.1)
-      safely_block (>= 0.4)
+      railties (>= 7.2)
+      safely_block (>= 1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
@@ -174,7 +174,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    good_job (4.18.1)
+    good_job (4.18.2)
       activejob (>= 6.1.0)
       activerecord (>= 6.1.0)
       concurrent-ruby (>= 1.3.1)
@@ -269,7 +269,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.4)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -589,7 +589,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (= 1.9.2)
-  blazer (= 3.3.0)
+  blazer (= 3.4.0)
   bootsnap (= 1.23.0)
   brakeman (= 8.0.4)
   bullet (= 8.1.0)
@@ -604,7 +604,7 @@ DEPENDENCIES
   factory_bot_rails (= 6.5.1)
   faker (= 3.8.0)
   foreman (= 0.90.0)
-  good_job (= 4.18.1)
+  good_job (= 4.18.2)
   image_processing (= 1.14.0)
   importmap-rails (= 2.2.3)
   jbuilder (= 2.14.1)
@@ -673,7 +673,7 @@ CHECKSUMS
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  blazer (3.3.0) sha256=01e151091ce1e7d27c156243916b2f13109ef2ef1a16cfa62bef67f4c5fd169f
+  blazer (3.4.0) sha256=ff8d4e32013857f3614772ccd74018955ae126005460065dbc9036cc5ed9cc7d
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
@@ -716,7 +716,7 @@ CHECKSUMS
   foreman (0.90.0) sha256=ff675e2d47b607ac58714a6d4ac3e1ee8f06f41d8db084531c31961e2c3f117c
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  good_job (4.18.1) sha256=cdd3f764752c47ab5d52b71d6e09097572c51c0a48cabb86157d403ac5269972
+  good_job (4.18.2) sha256=7e557a15865fc7b7ad4ab71644cf1d4189a2a1869d3b381e5e88741c540beca6
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   htmlbeautifier (1.4.3) sha256=b43d08f7e2aa6ae1b5a6f0607b4ed8954c8d4a8e85fd2336f975dda1e4db385b
   htmlentities (4.3.4) sha256=125a73c6c9f2d1b62100b7c3c401e3624441b663762afa7fe428476435a673da
@@ -746,7 +746,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
+  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3


### PR DESCRIPTION
## Gem Updates

This PR updates the following Ruby gems:

### Updated gems
- blazer: updated to 3.4.0
- diff-lcs: transitive dependency updated to 2.0.0
- good_job: updated to 4.18.2
- htmlentities: transitive dependency updated to 4.4.2
- minitest: transitive dependency updated to 6.0.5

### Skipped gems (have comments indicating breaking changes)
_None_

### Changes to Gemfile
```diff
diff --git a/Gemfile b/Gemfile
index f74b9e1..7f64104 100644
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,14 @@ gem "rails", "8.1.3"
 # gem install bundler
 
 gem "awesome_print", "1.9.2"
-gem "blazer", "3.3.0"
+gem "blazer", "3.4.0"
 gem "bootsnap", "1.23.0", require: false
 gem "caxlsx_rails", "0.7.1"
 gem "cssbundling-rails", "1.4.3"
 gem "csv", "3.3.5"
 gem "devise", "5.0.3"
 gem "foreman", "0.90.0"
-gem "good_job", "4.18.1"
+gem "good_job", "4.18.2"
 gem "image_processing", "1.14.0"
 gem "importmap-rails", "2.2.3"
 gem "jbuilder", "2.14.1"
```

### Changes to Gemfile.lock
<details>
<summary>Click to expand Gemfile.lock changes</summary>

```diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 67988f4..282fe38 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,12 +84,12 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    blazer (3.3.0)
-      activerecord (>= 7.1)
+    blazer (3.4.0)
+      activerecord (>= 7.2)
       chartkick (>= 5)
       csv
-      railties (>= 7.1)
-      safely_block (>= 0.4)
+      railties (>= 7.2)
+      safely_block (>= 1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
@@ -174,7 +174,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    good_job (4.18.1)
+    good_job (4.18.2)
       activejob (>= 6.1.0)
       activerecord (>= 6.1.0)
       concurrent-ruby (>= 1.3.1)
@@ -269,7 +269,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.4)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -589,7 +589,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (= 1.9.2)
-  blazer (= 3.3.0)
+  blazer (= 3.4.0)
   bootsnap (= 1.23.0)
   brakeman (= 8.0.4)
   bullet (= 8.1.0)
@@ -604,7 +604,7 @@ DEPENDENCIES
   factory_bot_rails (= 6.5.1)
   faker (= 3.8.0)
   foreman (= 0.90.0)
-  good_job (= 4.18.1)
+  good_job (= 4.18.2)
   image_processing (= 1.14.0)
   importmap-rails (= 2.2.3)
   jbuilder (= 2.14.1)
@@ -673,7 +673,7 @@ CHECKSUMS
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  blazer (3.3.0) sha256=01e151091ce1e7d27c156243916b2f13109ef2ef1a16cfa62bef67f4c5fd169f
+  blazer (3.4.0) sha256=ff8d4e32013857f3614772ccd74018955ae126005460065dbc9036cc5ed9cc7d
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
@@ -716,7 +716,7 @@ CHECKSUMS
   foreman (0.90.0) sha256=ff675e2d47b607ac58714a6d4ac3e1ee8f06f41d8db084531c31961e2c3f117c
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  good_job (4.18.1) sha256=cdd3f764752c47ab5d52b71d6e09097572c51c0a48cabb86157d403ac5269972
+  good_job (4.18.2) sha256=7e557a15865fc7b7ad4ab71644cf1d4189a2a1869d3b381e5e88741c540beca6
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   htmlbeautifier (1.4.3) sha256=b43d08f7e2aa6ae1b5a6f0607b4ed8954c8d4a8e85fd2336f975dda1e4db385b
   htmlentities (4.3.4) sha256=125a73c6c9f2d1b62100b7c3c401e3624441b663762afa7fe428476435a673da
@@ -746,7 +746,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
+  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
```

</details>

*Generated automatically by `bin/update-gems-gha`*