### PR TITLE
ci: grant write permissions to scheduled update workflows

### DIFF
--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 12 * * *' # 06:00 CST (UTC-6)
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-gems:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -5,6 +5,10 @@ on:
     - cron: '5 12 * * *' # 06:05 CST (UTC-6)
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fixes the daily `Update Gems` / `Update Packages` scheduled workflows, which have been failing with HTTP 403 on `git push`.
- Adds a minimal workflow-level `permissions:` block (`contents: write`, `pull-requests: write`) to both workflows.

## Failure

Most recent failed run: https://github.com/wrburgess/baseline/actions/runs/24835075603/job/72693108046

```
remote: Permission to wrburgess/baseline.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/wrburgess/baseline/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```

Three consecutive scheduled `Update Gems` runs failed identically (2026-04-21, 2026-04-22, 2026-04-23). `Update Packages` shares the same workflow shape and has the same latent bug.

## Root Cause

Neither workflow declared a `permissions:` block. Under the repository's default token policy, the scheduled `GITHUB_TOKEN` was issued read-only (logs confirm `Contents: read, Metadata: read`). `bin/update-gems` and `bin/update-packages` both:

1. `git push -u origin chore/update-...` — requires `contents: write`
2. `gh pr create ...` — requires `pull-requests: write`

Both steps would 403 under a read-only token.

## Technical Approach

Add an explicit workflow-level `permissions:` block to each scheduled update workflow:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Workflow-level `permissions:` overrides the repo default, so no repo Settings changes are required. The scope is intentionally narrow — only what `git push` and `gh pr create` need.

### Alternatives considered

- **Repo Settings → Actions → Workflow permissions = Read and write** — broader (applies to *all* workflows), less principled. Rejected.
- **Fine-scoped PAT via secrets, passed to `actions/checkout` and `git push`** — more setup, but has one advantage: `GITHUB_TOKEN`-authored pushes do not trigger downstream workflows, so the PRs opened by these jobs will not run `ci-rails.yml` on push. If we want the update PRs to run CI automatically, we'll need to revisit with a PAT (or manually re-trigger from the PR).

## Testing

- [ ] Manually dispatch `Update Gems` (Actions → Update Gems → Run workflow) on this branch after merge and confirm it pushes a branch and opens a PR.
- [ ] Same for `Update Packages`.
- [ ] Confirm the next scheduled run (06:00 CST) succeeds.

## Checklist

- [x] Narrow token scope (only `contents` + `pull-requests`, both `write`)
- [x] No other workflow files modified
- [x] No repo-level Settings changes required

## Possible follow-up

If the PRs opened by these jobs need to trigger `ci-rails.yml`, we'll need a PAT-based approach (GitHub intentionally does not recurse workflows triggered by `GITHUB_TOKEN`). Out of scope for this PR.

— Claude Code (Opus 4.7)