### PR TITLE
Phase 1A: Foundation — concerns, enum modules, SystemOperations canonicalization

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -11,7 +11,7 @@ class AdminController < ApplicationController
     authorize(@instance)
 
     @instance.archive!
-    @instance.log(user: current_user, operation: action_nameD)
+    @instance.log(user: current_user, operation: action_name)
     flash[:danger] = "#{@instance.class_name_title} deleted"
     redirect_to polymorphic_path([ :admin, @model_class ])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
 
+  private
+
   def controller_class
     controller_name.classify.safe_constantize
   end
@@ -24,8 +26,6 @@ class ApplicationController < ActionController::Base
   def controller_class_symbolized
     controller_name.underscore.singularize.to_sym
   end
-
-  private
 
   def user_not_authorized(_exception = nil)
     flash[:error] = "You are not authorized to perform this action."

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -18,7 +18,15 @@ module Archivable
     update(archived_at: DateTime.current)
   end
 
+  def archive!
+    update!(archived_at: DateTime.current)
+  end
+
   def unarchive
     update(archived_at: nil)
+  end
+
+  def unarchive!
+    update!(archived_at: nil)
   end
 end

--- a/app/modules/age_levels.rb
+++ b/app/modules/age_levels.rb
@@ -1,0 +1,21 @@
+module AgeLevels
+  AGE_18_PLUS = "18_plus".freeze
+  AGE_40_PLUS = "40_plus".freeze
+  AGE_55_PLUS = "55_plus".freeze
+  AGE_65_PLUS = "65_plus".freeze
+  AGE_70_PLUS = "70_plus".freeze
+
+  def self.all
+    [
+      AGE_18_PLUS,
+      AGE_40_PLUS,
+      AGE_55_PLUS,
+      AGE_65_PLUS,
+      AGE_70_PLUS
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/alias_sources.rb
+++ b/app/modules/alias_sources.rb
@@ -1,0 +1,17 @@
+module AliasSources
+  CAPTAIN_ENTERED = "captain_entered".freeze
+  PARSER_OBSERVED = "parser_observed".freeze
+  IMPORTED = "imported".freeze
+
+  def self.all
+    [
+      CAPTAIN_ENTERED,
+      PARSER_OBSERVED,
+      IMPORTED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/game_format_types.rb
+++ b/app/modules/game_format_types.rb
@@ -1,0 +1,21 @@
+module GameFormatTypes
+  LEVEL = "level".freeze
+  TRI_LEVEL = "tri_level".freeze
+  MIXED_DOUBLES = "mixed_doubles".freeze
+  COMBO_DOUBLES = "combo_doubles".freeze
+  SINGLES_ONLY = "singles_only".freeze
+
+  def self.all
+    [
+      LEVEL,
+      TRI_LEVEL,
+      MIXED_DOUBLES,
+      COMBO_DOUBLES,
+      SINGLES_ONLY
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/gender_types.rb
+++ b/app/modules/gender_types.rb
@@ -1,0 +1,17 @@
+module GenderTypes
+  MEN = "men".freeze
+  WOMEN = "women".freeze
+  MIXED = "mixed".freeze
+
+  def self.all
+    [
+      MEN,
+      WOMEN,
+      MIXED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/grade_rationales.rb
+++ b/app/modules/grade_rationales.rb
@@ -1,0 +1,29 @@
+module GradeRationales
+  SELF_RATED = "self_rated".freeze
+  YEAR_END_COMPUTER = "year_end_computer".freeze
+  EARLY_START_BUMP = "early_start_bump".freeze
+  MID_YEAR_BUMP = "mid_year_bump".freeze
+  THREE_STRIKE_DQ = "three_strike_dq".freeze
+  APPEAL_GRANTED = "appeal_granted".freeze
+  APPEAL_DENIED = "appeal_denied".freeze
+  MANUAL = "manual".freeze
+  UNKNOWN_LEGACY = "unknown_legacy".freeze
+
+  def self.all
+    [
+      SELF_RATED,
+      YEAR_END_COMPUTER,
+      EARLY_START_BUMP,
+      MID_YEAR_BUMP,
+      THREE_STRIKE_DQ,
+      APPEAL_GRANTED,
+      APPEAL_DENIED,
+      MANUAL,
+      UNKNOWN_LEGACY
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/grade_sources.rb
+++ b/app/modules/grade_sources.rb
@@ -1,0 +1,21 @@
+module GradeSources
+  MANUAL = "manual".freeze
+  PARSER_TENNISRECORD = "parser_tennisrecord".freeze
+  PARSER_WTN = "parser_wtn".freeze
+  PARSER_TENNISLINK = "parser_tennislink".freeze
+  IMPORTED = "imported".freeze
+
+  def self.all
+    [
+      MANUAL,
+      PARSER_TENNISRECORD,
+      PARSER_WTN,
+      PARSER_TENNISLINK,
+      IMPORTED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/grade_statuses.rb
+++ b/app/modules/grade_statuses.rb
@@ -1,0 +1,19 @@
+module GradeStatuses
+  ACTIVE = "active".freeze
+  APPEALED = "appealed".freeze
+  DQ = "dq".freeze
+  MANUAL = "manual".freeze
+
+  def self.all
+    [
+      ACTIVE,
+      APPEALED,
+      DQ,
+      MANUAL
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/h2h_formats.rb
+++ b/app/modules/h2h_formats.rb
@@ -1,0 +1,17 @@
+module H2HFormats
+  ALL = "all".freeze
+  SINGLES = "singles".freeze
+  DOUBLES = "doubles".freeze
+
+  def self.all
+    [
+      ALL,
+      SINGLES,
+      DOUBLES
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/import_kinds.rb
+++ b/app/modules/import_kinds.rb
@@ -1,0 +1,19 @@
+module ImportKinds
+  TEAM_ROSTER = "team_roster".freeze
+  MATCH_NIGHT = "match_night".freeze
+  PLAYER_RATINGS = "player_ratings".freeze
+  LEAGUE_SCHEDULE = "league_schedule".freeze
+
+  def self.all
+    [
+      TEAM_ROSTER,
+      MATCH_NIGHT,
+      PLAYER_RATINGS,
+      LEAGUE_SCHEDULE
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/import_source_types.rb
+++ b/app/modules/import_source_types.rb
@@ -1,0 +1,21 @@
+module ImportSourceTypes
+  TENNISLINK_TEAM_PAGE = "tennislink_team_page".freeze
+  TENNISLINK_MATCH_RESULTS = "tennislink_match_results".freeze
+  TENNISLINK_SCHEDULE_PAGE = "tennislink_schedule_page".freeze
+  TENNISRECORD_PLAYER_PAGE = "tennisrecord_player_page".freeze
+  WTN_PLAYER_PAGE = "wtn_player_page".freeze
+
+  def self.all
+    [
+      TENNISLINK_TEAM_PAGE,
+      TENNISLINK_MATCH_RESULTS,
+      TENNISLINK_SCHEDULE_PAGE,
+      TENNISRECORD_PLAYER_PAGE,
+      WTN_PLAYER_PAGE
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/import_statuses.rb
+++ b/app/modules/import_statuses.rb
@@ -1,0 +1,21 @@
+module ImportStatuses
+  UPLOADED = "uploaded".freeze
+  PARSING = "parsing".freeze
+  NEEDS_REVIEW = "needs_review".freeze
+  COMMITTED = "committed".freeze
+  FAILED = "failed".freeze
+
+  def self.all
+    [
+      UPLOADED,
+      PARSING,
+      NEEDS_REVIEW,
+      COMMITTED,
+      FAILED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/match_formats.rb
+++ b/app/modules/match_formats.rb
@@ -1,0 +1,15 @@
+module MatchFormats
+  SINGLES = "singles".freeze
+  DOUBLES = "doubles".freeze
+
+  def self.all
+    [
+      SINGLES,
+      DOUBLES
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/match_outcomes.rb
+++ b/app/modules/match_outcomes.rb
@@ -1,0 +1,21 @@
+module MatchOutcomes
+  COMPLETED = "completed".freeze
+  RETIRED = "retired".freeze
+  DEFAULTED = "defaulted".freeze
+  WALKOVER = "walkover".freeze
+  TIMED = "timed".freeze
+
+  def self.all
+    [
+      COMPLETED,
+      RETIRED,
+      DEFAULTED,
+      WALKOVER,
+      TIMED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/match_rules_formats.rb
+++ b/app/modules/match_rules_formats.rb
@@ -1,0 +1,27 @@
+module MatchRulesFormats
+  BEST_OF_3_STANDARD = "best_of_3_standard".freeze
+  BEST_OF_3_MATCH_TB = "best_of_3_match_tb".freeze
+  FAST4 = "fast4".freeze
+  PRO_SET_8 = "pro_set_8".freeze
+  PRO_SET_10 = "pro_set_10".freeze
+  MATCH_TB_10 = "match_tb_10".freeze
+  MATCH_TB_7 = "match_tb_7".freeze
+  CUSTOM = "custom".freeze
+
+  def self.all
+    [
+      BEST_OF_3_STANDARD,
+      BEST_OF_3_MATCH_TB,
+      FAST4,
+      PRO_SET_8,
+      PRO_SET_10,
+      MATCH_TB_10,
+      MATCH_TB_7,
+      CUSTOM
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/match_sides.rb
+++ b/app/modules/match_sides.rb
@@ -1,0 +1,15 @@
+module MatchSides
+  HOME = "home".freeze
+  AWAY = "away".freeze
+
+  def self.all
+    [
+      HOME,
+      AWAY
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/player_genders.rb
+++ b/app/modules/player_genders.rb
@@ -1,0 +1,17 @@
+module PlayerGenders
+  MALE = "male".freeze
+  FEMALE = "female".freeze
+  NONBINARY = "nonbinary".freeze
+
+  def self.all
+    [
+      MALE,
+      FEMALE,
+      NONBINARY
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/rating_systems.rb
+++ b/app/modules/rating_systems.rb
@@ -1,0 +1,25 @@
+module RatingSystems
+  USTA_NTRP = "usta_ntrp".freeze
+  TENNIS_RECORD = "tennis_record".freeze
+  WTN_DYNAMIC = "wtn_dynamic".freeze
+  WTN_SINGLES = "wtn_singles".freeze
+  UTR_DYNAMIC = "utr_dynamic".freeze
+  UTR_SINGLES = "utr_singles".freeze
+  UTR_DOUBLES = "utr_doubles".freeze
+
+  def self.all
+    [
+      USTA_NTRP,
+      TENNIS_RECORD,
+      WTN_DYNAMIC,
+      WTN_SINGLES,
+      UTR_DYNAMIC,
+      UTR_SINGLES,
+      UTR_DOUBLES
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/rating_types.rb
+++ b/app/modules/rating_types.rb
@@ -1,0 +1,19 @@
+module RatingTypes
+  S = "S".freeze
+  C = "C".freeze
+  A = "A".freeze
+  M = "M".freeze
+
+  def self.all
+    [
+      S,
+      C,
+      A,
+      M
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/scheduled_fixture_statuses.rb
+++ b/app/modules/scheduled_fixture_statuses.rb
@@ -1,0 +1,21 @@
+module ScheduledFixtureStatuses
+  SCHEDULED = "scheduled".freeze
+  COMPLETED = "completed".freeze
+  POSTPONED = "postponed".freeze
+  CANCELLED = "cancelled".freeze
+  DEFAULTED = "defaulted".freeze
+
+  def self.all
+    [
+      SCHEDULED,
+      COMPLETED,
+      POSTPONED,
+      CANCELLED,
+      DEFAULTED
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/system_operations.rb
+++ b/app/modules/system_operations.rb
@@ -1,21 +1,27 @@
 module SystemOperations
-  ARCHIVED = "archived".freeze
+  ARCHIVE = "archive".freeze
   COLLECTION_EXPORT_XLSX = "collection_export_xlsx".freeze
+  COMMIT = "commit".freeze
   COPY = "copy".freeze
   CREATE = "create".freeze
   CREATE_FROM_UPLOAD = "create_from_upload".freeze
-  DELETED = "deleted".freeze
+  DESTROY = "destroy".freeze
+  DISAMBIGUATE = "disambiguate".freeze
   DISASSOCIATE = "disassociate".freeze
   EDIT = "edit".freeze
+  ENTER_MATCH_NIGHT = "enter_match_night".freeze
   EXPORT_IMPORT_EXAMPLE = "export_import_example".freeze
   IMPORT = "import".freeze
   INDEX = "index".freeze
+  LINK_FIXTURE = "link_fixture".freeze
   MEMBER_EXPORT_XLSX = "member_export_xlsx".freeze
+  MERGE = "merge".freeze
   NEW = "new".freeze
   READ = "read".freeze
+  REJECT = "reject".freeze
   SHARE = "share".freeze
   SHOW = "show".freeze
-  UNARCHIVED = "unarchived".freeze
+  UNARCHIVE = "unarchive".freeze
   UPDATE = "update".freeze
   UPLOAD = "upload".freeze
 

--- a/app/modules/system_operations.rb
+++ b/app/modules/system_operations.rb
@@ -11,6 +11,7 @@ module SystemOperations
   EDIT = "edit".freeze
   ENTER_MATCH_NIGHT = "enter_match_night".freeze
   EXPORT_IMPORT_EXAMPLE = "export_import_example".freeze
+  IMPERSONATE = "impersonate".freeze
   IMPORT = "import".freeze
   INDEX = "index".freeze
   LINK_FIXTURE = "link_fixture".freeze
@@ -21,6 +22,7 @@ module SystemOperations
   REJECT = "reject".freeze
   SHARE = "share".freeze
   SHOW = "show".freeze
+  TRIGGER_PASSWORD_RESET_EMAIL = "trigger_password_reset_email".freeze
   UNARCHIVE = "unarchive".freeze
   UPDATE = "update".freeze
   UPLOAD = "upload".freeze

--- a/app/modules/team_match_levels.rb
+++ b/app/modules/team_match_levels.rb
@@ -1,0 +1,23 @@
+module TeamMatchLevels
+  REGULAR_SEASON = "regular_season".freeze
+  LOCAL_PLAYOFF = "local_playoff".freeze
+  DISTRICT = "district".freeze
+  SECTION = "section".freeze
+  NATIONAL = "national".freeze
+  TOURNAMENT = "tournament".freeze
+
+  def self.all
+    [
+      REGULAR_SEASON,
+      LOCAL_PLAYOFF,
+      DISTRICT,
+      SECTION,
+      NATIONAL,
+      TOURNAMENT
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/app/modules/team_player_roles.rb
+++ b/app/modules/team_player_roles.rb
@@ -1,0 +1,17 @@
+module TeamPlayerRoles
+  PLAYER = "player".freeze
+  CO_CAPTAIN = "co_captain".freeze
+  CAPTAIN = "captain".freeze
+
+  def self.all
+    [
+      PLAYER,
+      CO_CAPTAIN,
+      CAPTAIN
+    ]
+  end
+
+  def self.options_for_select
+    all.map { |item| [ item.titleize, item ] }
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "H2H"
+end

--- a/spec/models/concerns/archivable_spec.rb
+++ b/spec/models/concerns/archivable_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Archivable do
+  let(:described_class) { User }
+
+  describe "#archive!" do
+    it "transitions an active record to archived" do
+      user = create(:user, archived_at: nil)
+
+      expect { user.archive! }.to change { user.reload.archived? }.from(false).to(true)
+      expect(user.archived_at).to be_present
+      expect(user.active?).to be false
+    end
+
+    it "raises ActiveRecord::RecordInvalid when update! fails" do
+      user = create(:user, archived_at: nil)
+      allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(user))
+
+      expect { user.archive! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "#unarchive!" do
+    it "transitions an archived record to active" do
+      user = create(:user, archived_at: DateTime.current)
+
+      expect { user.unarchive! }.to change { user.reload.active? }.from(false).to(true)
+      expect(user.archived_at).to be_nil
+      expect(user.archived?).to be false
+    end
+
+    it "raises ActiveRecord::RecordInvalid when update! fails" do
+      user = create(:user, archived_at: DateTime.current)
+      allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(user))
+
+      expect { user.unarchive! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/modules/age_levels_spec.rb
+++ b/spec/modules/age_levels_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe AgeLevels do
+  describe "constants" do
+    it "defines AGE_18_PLUS" do
+      expect(described_class::AGE_18_PLUS).to eq("18_plus")
+    end
+
+    it "defines AGE_40_PLUS" do
+      expect(described_class::AGE_40_PLUS).to eq("40_plus")
+    end
+
+    it "defines AGE_55_PLUS" do
+      expect(described_class::AGE_55_PLUS).to eq("55_plus")
+    end
+
+    it "defines AGE_65_PLUS" do
+      expect(described_class::AGE_65_PLUS).to eq("65_plus")
+    end
+
+    it "defines AGE_70_PLUS" do
+      expect(described_class::AGE_70_PLUS).to eq("70_plus")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "18_plus",
+          "40_plus",
+          "55_plus",
+          "65_plus",
+          "70_plus"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::AGE_18_PLUS).to be_frozen
+      expect(described_class::AGE_40_PLUS).to be_frozen
+      expect(described_class::AGE_55_PLUS).to be_frozen
+      expect(described_class::AGE_65_PLUS).to be_frozen
+      expect(described_class::AGE_70_PLUS).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "18 Plus", "18_plus" ],
+          [ "40 Plus", "40_plus" ],
+          [ "55 Plus", "55_plus" ],
+          [ "65 Plus", "65_plus" ],
+          [ "70 Plus", "70_plus" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/alias_sources_spec.rb
+++ b/spec/modules/alias_sources_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe AliasSources do
+  describe "constants" do
+    it "defines CAPTAIN_ENTERED" do
+      expect(described_class::CAPTAIN_ENTERED).to eq("captain_entered")
+    end
+
+    it "defines PARSER_OBSERVED" do
+      expect(described_class::PARSER_OBSERVED).to eq("parser_observed")
+    end
+
+    it "defines IMPORTED" do
+      expect(described_class::IMPORTED).to eq("imported")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "captain_entered",
+          "parser_observed",
+          "imported"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::CAPTAIN_ENTERED).to be_frozen
+      expect(described_class::PARSER_OBSERVED).to be_frozen
+      expect(described_class::IMPORTED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Captain Entered", "captain_entered" ],
+          [ "Parser Observed", "parser_observed" ],
+          [ "Imported", "imported" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/game_format_types_spec.rb
+++ b/spec/modules/game_format_types_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe GameFormatTypes do
+  describe "constants" do
+    it "defines LEVEL" do
+      expect(described_class::LEVEL).to eq("level")
+    end
+
+    it "defines TRI_LEVEL" do
+      expect(described_class::TRI_LEVEL).to eq("tri_level")
+    end
+
+    it "defines MIXED_DOUBLES" do
+      expect(described_class::MIXED_DOUBLES).to eq("mixed_doubles")
+    end
+
+    it "defines COMBO_DOUBLES" do
+      expect(described_class::COMBO_DOUBLES).to eq("combo_doubles")
+    end
+
+    it "defines SINGLES_ONLY" do
+      expect(described_class::SINGLES_ONLY).to eq("singles_only")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "level",
+          "tri_level",
+          "mixed_doubles",
+          "combo_doubles",
+          "singles_only"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::LEVEL).to be_frozen
+      expect(described_class::TRI_LEVEL).to be_frozen
+      expect(described_class::MIXED_DOUBLES).to be_frozen
+      expect(described_class::COMBO_DOUBLES).to be_frozen
+      expect(described_class::SINGLES_ONLY).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Level", "level" ],
+          [ "Tri Level", "tri_level" ],
+          [ "Mixed Doubles", "mixed_doubles" ],
+          [ "Combo Doubles", "combo_doubles" ],
+          [ "Singles Only", "singles_only" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/gender_types_spec.rb
+++ b/spec/modules/gender_types_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe GenderTypes do
+  describe "constants" do
+    it "defines MEN" do
+      expect(described_class::MEN).to eq("men")
+    end
+
+    it "defines WOMEN" do
+      expect(described_class::WOMEN).to eq("women")
+    end
+
+    it "defines MIXED" do
+      expect(described_class::MIXED).to eq("mixed")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "men",
+          "women",
+          "mixed"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::MEN).to be_frozen
+      expect(described_class::WOMEN).to be_frozen
+      expect(described_class::MIXED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Men", "men" ],
+          [ "Women", "women" ],
+          [ "Mixed", "mixed" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/grade_rationales_spec.rb
+++ b/spec/modules/grade_rationales_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe GradeRationales do
+  describe "constants" do
+    it "defines SELF_RATED" do
+      expect(described_class::SELF_RATED).to eq("self_rated")
+    end
+
+    it "defines YEAR_END_COMPUTER" do
+      expect(described_class::YEAR_END_COMPUTER).to eq("year_end_computer")
+    end
+
+    it "defines EARLY_START_BUMP" do
+      expect(described_class::EARLY_START_BUMP).to eq("early_start_bump")
+    end
+
+    it "defines MID_YEAR_BUMP" do
+      expect(described_class::MID_YEAR_BUMP).to eq("mid_year_bump")
+    end
+
+    it "defines THREE_STRIKE_DQ" do
+      expect(described_class::THREE_STRIKE_DQ).to eq("three_strike_dq")
+    end
+
+    it "defines APPEAL_GRANTED" do
+      expect(described_class::APPEAL_GRANTED).to eq("appeal_granted")
+    end
+
+    it "defines APPEAL_DENIED" do
+      expect(described_class::APPEAL_DENIED).to eq("appeal_denied")
+    end
+
+    it "defines MANUAL" do
+      expect(described_class::MANUAL).to eq("manual")
+    end
+
+    it "defines UNKNOWN_LEGACY" do
+      expect(described_class::UNKNOWN_LEGACY).to eq("unknown_legacy")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "self_rated",
+          "year_end_computer",
+          "early_start_bump",
+          "mid_year_bump",
+          "three_strike_dq",
+          "appeal_granted",
+          "appeal_denied",
+          "manual",
+          "unknown_legacy"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::SELF_RATED).to be_frozen
+      expect(described_class::YEAR_END_COMPUTER).to be_frozen
+      expect(described_class::EARLY_START_BUMP).to be_frozen
+      expect(described_class::MID_YEAR_BUMP).to be_frozen
+      expect(described_class::THREE_STRIKE_DQ).to be_frozen
+      expect(described_class::APPEAL_GRANTED).to be_frozen
+      expect(described_class::APPEAL_DENIED).to be_frozen
+      expect(described_class::MANUAL).to be_frozen
+      expect(described_class::UNKNOWN_LEGACY).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Self Rated", "self_rated" ],
+          [ "Year End Computer", "year_end_computer" ],
+          [ "Early Start Bump", "early_start_bump" ],
+          [ "Mid Year Bump", "mid_year_bump" ],
+          [ "Three Strike Dq", "three_strike_dq" ],
+          [ "Appeal Granted", "appeal_granted" ],
+          [ "Appeal Denied", "appeal_denied" ],
+          [ "Manual", "manual" ],
+          [ "Unknown Legacy", "unknown_legacy" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/grade_sources_spec.rb
+++ b/spec/modules/grade_sources_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe GradeSources do
+  describe "constants" do
+    it "defines MANUAL" do
+      expect(described_class::MANUAL).to eq("manual")
+    end
+
+    it "defines PARSER_TENNISRECORD" do
+      expect(described_class::PARSER_TENNISRECORD).to eq("parser_tennisrecord")
+    end
+
+    it "defines PARSER_WTN" do
+      expect(described_class::PARSER_WTN).to eq("parser_wtn")
+    end
+
+    it "defines PARSER_TENNISLINK" do
+      expect(described_class::PARSER_TENNISLINK).to eq("parser_tennislink")
+    end
+
+    it "defines IMPORTED" do
+      expect(described_class::IMPORTED).to eq("imported")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "manual",
+          "parser_tennisrecord",
+          "parser_wtn",
+          "parser_tennislink",
+          "imported"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::MANUAL).to be_frozen
+      expect(described_class::PARSER_TENNISRECORD).to be_frozen
+      expect(described_class::PARSER_WTN).to be_frozen
+      expect(described_class::PARSER_TENNISLINK).to be_frozen
+      expect(described_class::IMPORTED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Manual", "manual" ],
+          [ "Parser Tennisrecord", "parser_tennisrecord" ],
+          [ "Parser Wtn", "parser_wtn" ],
+          [ "Parser Tennislink", "parser_tennislink" ],
+          [ "Imported", "imported" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/grade_statuses_spec.rb
+++ b/spec/modules/grade_statuses_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe GradeStatuses do
+  describe "constants" do
+    it "defines ACTIVE" do
+      expect(described_class::ACTIVE).to eq("active")
+    end
+
+    it "defines APPEALED" do
+      expect(described_class::APPEALED).to eq("appealed")
+    end
+
+    it "defines DQ" do
+      expect(described_class::DQ).to eq("dq")
+    end
+
+    it "defines MANUAL" do
+      expect(described_class::MANUAL).to eq("manual")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "active",
+          "appealed",
+          "dq",
+          "manual"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::ACTIVE).to be_frozen
+      expect(described_class::APPEALED).to be_frozen
+      expect(described_class::DQ).to be_frozen
+      expect(described_class::MANUAL).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Active", "active" ],
+          [ "Appealed", "appealed" ],
+          [ "Dq", "dq" ],
+          [ "Manual", "manual" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/h2h_formats_spec.rb
+++ b/spec/modules/h2h_formats_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe H2HFormats do
+  describe "constants" do
+    it "defines ALL" do
+      expect(described_class::ALL).to eq("all")
+    end
+
+    it "defines SINGLES" do
+      expect(described_class::SINGLES).to eq("singles")
+    end
+
+    it "defines DOUBLES" do
+      expect(described_class::DOUBLES).to eq("doubles")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "all",
+          "singles",
+          "doubles"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::ALL).to be_frozen
+      expect(described_class::SINGLES).to be_frozen
+      expect(described_class::DOUBLES).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "All", "all" ],
+          [ "Singles", "singles" ],
+          [ "Doubles", "doubles" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/import_kinds_spec.rb
+++ b/spec/modules/import_kinds_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe ImportKinds do
+  describe "constants" do
+    it "defines TEAM_ROSTER" do
+      expect(described_class::TEAM_ROSTER).to eq("team_roster")
+    end
+
+    it "defines MATCH_NIGHT" do
+      expect(described_class::MATCH_NIGHT).to eq("match_night")
+    end
+
+    it "defines PLAYER_RATINGS" do
+      expect(described_class::PLAYER_RATINGS).to eq("player_ratings")
+    end
+
+    it "defines LEAGUE_SCHEDULE" do
+      expect(described_class::LEAGUE_SCHEDULE).to eq("league_schedule")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "team_roster",
+          "match_night",
+          "player_ratings",
+          "league_schedule"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::TEAM_ROSTER).to be_frozen
+      expect(described_class::MATCH_NIGHT).to be_frozen
+      expect(described_class::PLAYER_RATINGS).to be_frozen
+      expect(described_class::LEAGUE_SCHEDULE).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Team Roster", "team_roster" ],
+          [ "Match Night", "match_night" ],
+          [ "Player Ratings", "player_ratings" ],
+          [ "League Schedule", "league_schedule" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/import_source_types_spec.rb
+++ b/spec/modules/import_source_types_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe ImportSourceTypes do
+  describe "constants" do
+    it "defines TENNISLINK_TEAM_PAGE" do
+      expect(described_class::TENNISLINK_TEAM_PAGE).to eq("tennislink_team_page")
+    end
+
+    it "defines TENNISLINK_MATCH_RESULTS" do
+      expect(described_class::TENNISLINK_MATCH_RESULTS).to eq("tennislink_match_results")
+    end
+
+    it "defines TENNISLINK_SCHEDULE_PAGE" do
+      expect(described_class::TENNISLINK_SCHEDULE_PAGE).to eq("tennislink_schedule_page")
+    end
+
+    it "defines TENNISRECORD_PLAYER_PAGE" do
+      expect(described_class::TENNISRECORD_PLAYER_PAGE).to eq("tennisrecord_player_page")
+    end
+
+    it "defines WTN_PLAYER_PAGE" do
+      expect(described_class::WTN_PLAYER_PAGE).to eq("wtn_player_page")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "tennislink_team_page",
+          "tennislink_match_results",
+          "tennislink_schedule_page",
+          "tennisrecord_player_page",
+          "wtn_player_page"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::TENNISLINK_TEAM_PAGE).to be_frozen
+      expect(described_class::TENNISLINK_MATCH_RESULTS).to be_frozen
+      expect(described_class::TENNISLINK_SCHEDULE_PAGE).to be_frozen
+      expect(described_class::TENNISRECORD_PLAYER_PAGE).to be_frozen
+      expect(described_class::WTN_PLAYER_PAGE).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Tennislink Team Page", "tennislink_team_page" ],
+          [ "Tennislink Match Results", "tennislink_match_results" ],
+          [ "Tennislink Schedule Page", "tennislink_schedule_page" ],
+          [ "Tennisrecord Player Page", "tennisrecord_player_page" ],
+          [ "Wtn Player Page", "wtn_player_page" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/import_statuses_spec.rb
+++ b/spec/modules/import_statuses_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe ImportStatuses do
+  describe "constants" do
+    it "defines UPLOADED" do
+      expect(described_class::UPLOADED).to eq("uploaded")
+    end
+
+    it "defines PARSING" do
+      expect(described_class::PARSING).to eq("parsing")
+    end
+
+    it "defines NEEDS_REVIEW" do
+      expect(described_class::NEEDS_REVIEW).to eq("needs_review")
+    end
+
+    it "defines COMMITTED" do
+      expect(described_class::COMMITTED).to eq("committed")
+    end
+
+    it "defines FAILED" do
+      expect(described_class::FAILED).to eq("failed")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "uploaded",
+          "parsing",
+          "needs_review",
+          "committed",
+          "failed"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::UPLOADED).to be_frozen
+      expect(described_class::PARSING).to be_frozen
+      expect(described_class::NEEDS_REVIEW).to be_frozen
+      expect(described_class::COMMITTED).to be_frozen
+      expect(described_class::FAILED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Uploaded", "uploaded" ],
+          [ "Parsing", "parsing" ],
+          [ "Needs Review", "needs_review" ],
+          [ "Committed", "committed" ],
+          [ "Failed", "failed" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/match_formats_spec.rb
+++ b/spec/modules/match_formats_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe MatchFormats do
+  describe "constants" do
+    it "defines SINGLES" do
+      expect(described_class::SINGLES).to eq("singles")
+    end
+
+    it "defines DOUBLES" do
+      expect(described_class::DOUBLES).to eq("doubles")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "singles",
+          "doubles"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::SINGLES).to be_frozen
+      expect(described_class::DOUBLES).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Singles", "singles" ],
+          [ "Doubles", "doubles" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/match_outcomes_spec.rb
+++ b/spec/modules/match_outcomes_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe MatchOutcomes do
+  describe "constants" do
+    it "defines COMPLETED" do
+      expect(described_class::COMPLETED).to eq("completed")
+    end
+
+    it "defines RETIRED" do
+      expect(described_class::RETIRED).to eq("retired")
+    end
+
+    it "defines DEFAULTED" do
+      expect(described_class::DEFAULTED).to eq("defaulted")
+    end
+
+    it "defines WALKOVER" do
+      expect(described_class::WALKOVER).to eq("walkover")
+    end
+
+    it "defines TIMED" do
+      expect(described_class::TIMED).to eq("timed")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "completed",
+          "retired",
+          "defaulted",
+          "walkover",
+          "timed"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::COMPLETED).to be_frozen
+      expect(described_class::RETIRED).to be_frozen
+      expect(described_class::DEFAULTED).to be_frozen
+      expect(described_class::WALKOVER).to be_frozen
+      expect(described_class::TIMED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Completed", "completed" ],
+          [ "Retired", "retired" ],
+          [ "Defaulted", "defaulted" ],
+          [ "Walkover", "walkover" ],
+          [ "Timed", "timed" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/match_rules_formats_spec.rb
+++ b/spec/modules/match_rules_formats_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe MatchRulesFormats do
+  describe "constants" do
+    it "defines BEST_OF_3_STANDARD" do
+      expect(described_class::BEST_OF_3_STANDARD).to eq("best_of_3_standard")
+    end
+
+    it "defines BEST_OF_3_MATCH_TB" do
+      expect(described_class::BEST_OF_3_MATCH_TB).to eq("best_of_3_match_tb")
+    end
+
+    it "defines FAST4" do
+      expect(described_class::FAST4).to eq("fast4")
+    end
+
+    it "defines PRO_SET_8" do
+      expect(described_class::PRO_SET_8).to eq("pro_set_8")
+    end
+
+    it "defines PRO_SET_10" do
+      expect(described_class::PRO_SET_10).to eq("pro_set_10")
+    end
+
+    it "defines MATCH_TB_10" do
+      expect(described_class::MATCH_TB_10).to eq("match_tb_10")
+    end
+
+    it "defines MATCH_TB_7" do
+      expect(described_class::MATCH_TB_7).to eq("match_tb_7")
+    end
+
+    it "defines CUSTOM" do
+      expect(described_class::CUSTOM).to eq("custom")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "best_of_3_standard",
+          "best_of_3_match_tb",
+          "fast4",
+          "pro_set_8",
+          "pro_set_10",
+          "match_tb_10",
+          "match_tb_7",
+          "custom"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::BEST_OF_3_STANDARD).to be_frozen
+      expect(described_class::BEST_OF_3_MATCH_TB).to be_frozen
+      expect(described_class::FAST4).to be_frozen
+      expect(described_class::PRO_SET_8).to be_frozen
+      expect(described_class::PRO_SET_10).to be_frozen
+      expect(described_class::MATCH_TB_10).to be_frozen
+      expect(described_class::MATCH_TB_7).to be_frozen
+      expect(described_class::CUSTOM).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Best Of 3 Standard", "best_of_3_standard" ],
+          [ "Best Of 3 Match Tb", "best_of_3_match_tb" ],
+          [ "Fast4", "fast4" ],
+          [ "Pro Set 8", "pro_set_8" ],
+          [ "Pro Set 10", "pro_set_10" ],
+          [ "Match Tb 10", "match_tb_10" ],
+          [ "Match Tb 7", "match_tb_7" ],
+          [ "Custom", "custom" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/match_sides_spec.rb
+++ b/spec/modules/match_sides_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe MatchSides do
+  describe "constants" do
+    it "defines HOME" do
+      expect(described_class::HOME).to eq("home")
+    end
+
+    it "defines AWAY" do
+      expect(described_class::AWAY).to eq("away")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "home",
+          "away"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::HOME).to be_frozen
+      expect(described_class::AWAY).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Home", "home" ],
+          [ "Away", "away" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/player_genders_spec.rb
+++ b/spec/modules/player_genders_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe PlayerGenders do
+  describe "constants" do
+    it "defines MALE" do
+      expect(described_class::MALE).to eq("male")
+    end
+
+    it "defines FEMALE" do
+      expect(described_class::FEMALE).to eq("female")
+    end
+
+    it "defines NONBINARY" do
+      expect(described_class::NONBINARY).to eq("nonbinary")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "male",
+          "female",
+          "nonbinary"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::MALE).to be_frozen
+      expect(described_class::FEMALE).to be_frozen
+      expect(described_class::NONBINARY).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Male", "male" ],
+          [ "Female", "female" ],
+          [ "Nonbinary", "nonbinary" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/rating_systems_spec.rb
+++ b/spec/modules/rating_systems_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe RatingSystems do
+  describe "constants" do
+    it "defines USTA_NTRP" do
+      expect(described_class::USTA_NTRP).to eq("usta_ntrp")
+    end
+
+    it "defines TENNIS_RECORD" do
+      expect(described_class::TENNIS_RECORD).to eq("tennis_record")
+    end
+
+    it "defines WTN_DYNAMIC" do
+      expect(described_class::WTN_DYNAMIC).to eq("wtn_dynamic")
+    end
+
+    it "defines WTN_SINGLES" do
+      expect(described_class::WTN_SINGLES).to eq("wtn_singles")
+    end
+
+    it "defines UTR_DYNAMIC" do
+      expect(described_class::UTR_DYNAMIC).to eq("utr_dynamic")
+    end
+
+    it "defines UTR_SINGLES" do
+      expect(described_class::UTR_SINGLES).to eq("utr_singles")
+    end
+
+    it "defines UTR_DOUBLES" do
+      expect(described_class::UTR_DOUBLES).to eq("utr_doubles")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "usta_ntrp",
+          "tennis_record",
+          "wtn_dynamic",
+          "wtn_singles",
+          "utr_dynamic",
+          "utr_singles",
+          "utr_doubles"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::USTA_NTRP).to be_frozen
+      expect(described_class::TENNIS_RECORD).to be_frozen
+      expect(described_class::WTN_DYNAMIC).to be_frozen
+      expect(described_class::WTN_SINGLES).to be_frozen
+      expect(described_class::UTR_DYNAMIC).to be_frozen
+      expect(described_class::UTR_SINGLES).to be_frozen
+      expect(described_class::UTR_DOUBLES).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Usta Ntrp", "usta_ntrp" ],
+          [ "Tennis Record", "tennis_record" ],
+          [ "Wtn Dynamic", "wtn_dynamic" ],
+          [ "Wtn Singles", "wtn_singles" ],
+          [ "Utr Dynamic", "utr_dynamic" ],
+          [ "Utr Singles", "utr_singles" ],
+          [ "Utr Doubles", "utr_doubles" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/rating_types_spec.rb
+++ b/spec/modules/rating_types_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe RatingTypes do
+  describe "constants" do
+    it "defines S" do
+      expect(described_class::S).to eq("S")
+    end
+
+    it "defines C" do
+      expect(described_class::C).to eq("C")
+    end
+
+    it "defines A" do
+      expect(described_class::A).to eq("A")
+    end
+
+    it "defines M" do
+      expect(described_class::M).to eq("M")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "S",
+          "C",
+          "A",
+          "M"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::S).to be_frozen
+      expect(described_class::C).to be_frozen
+      expect(described_class::A).to be_frozen
+      expect(described_class::M).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "S", "S" ],
+          [ "C", "C" ],
+          [ "A", "A" ],
+          [ "M", "M" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/scheduled_fixture_statuses_spec.rb
+++ b/spec/modules/scheduled_fixture_statuses_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe ScheduledFixtureStatuses do
+  describe "constants" do
+    it "defines SCHEDULED" do
+      expect(described_class::SCHEDULED).to eq("scheduled")
+    end
+
+    it "defines COMPLETED" do
+      expect(described_class::COMPLETED).to eq("completed")
+    end
+
+    it "defines POSTPONED" do
+      expect(described_class::POSTPONED).to eq("postponed")
+    end
+
+    it "defines CANCELLED" do
+      expect(described_class::CANCELLED).to eq("cancelled")
+    end
+
+    it "defines DEFAULTED" do
+      expect(described_class::DEFAULTED).to eq("defaulted")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "scheduled",
+          "completed",
+          "postponed",
+          "cancelled",
+          "defaulted"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::SCHEDULED).to be_frozen
+      expect(described_class::COMPLETED).to be_frozen
+      expect(described_class::POSTPONED).to be_frozen
+      expect(described_class::CANCELLED).to be_frozen
+      expect(described_class::DEFAULTED).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Scheduled", "scheduled" ],
+          [ "Completed", "completed" ],
+          [ "Postponed", "postponed" ],
+          [ "Cancelled", "cancelled" ],
+          [ "Defaulted", "defaulted" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/system_operations_spec.rb
+++ b/spec/modules/system_operations_spec.rb
@@ -2,43 +2,144 @@ require "rails_helper"
 
 RSpec.describe SystemOperations do
   describe "constants" do
-    it "defines ARCHIVED" do
-      expect(described_class::ARCHIVED).to eq("archived")
+    it "defines ARCHIVE" do
+      expect(described_class::ARCHIVE).to eq("archive")
+    end
+
+    it "defines COLLECTION_EXPORT_XLSX" do
+      expect(described_class::COLLECTION_EXPORT_XLSX).to eq("collection_export_xlsx")
+    end
+
+    it "defines COMMIT" do
+      expect(described_class::COMMIT).to eq("commit")
+    end
+
+    it "defines COPY" do
+      expect(described_class::COPY).to eq("copy")
     end
 
     it "defines CREATE" do
       expect(described_class::CREATE).to eq("create")
     end
 
-    it "defines UPDATE" do
-      expect(described_class::UPDATE).to eq("update")
+    it "defines CREATE_FROM_UPLOAD" do
+      expect(described_class::CREATE_FROM_UPLOAD).to eq("create_from_upload")
     end
 
-    it "defines DELETED" do
-      expect(described_class::DELETED).to eq("deleted")
+    it "defines DESTROY" do
+      expect(described_class::DESTROY).to eq("destroy")
+    end
+
+    it "defines DISAMBIGUATE" do
+      expect(described_class::DISAMBIGUATE).to eq("disambiguate")
+    end
+
+    it "defines DISASSOCIATE" do
+      expect(described_class::DISASSOCIATE).to eq("disassociate")
+    end
+
+    it "defines EDIT" do
+      expect(described_class::EDIT).to eq("edit")
+    end
+
+    it "defines ENTER_MATCH_NIGHT" do
+      expect(described_class::ENTER_MATCH_NIGHT).to eq("enter_match_night")
+    end
+
+    it "defines EXPORT_IMPORT_EXAMPLE" do
+      expect(described_class::EXPORT_IMPORT_EXAMPLE).to eq("export_import_example")
+    end
+
+    it "defines IMPORT" do
+      expect(described_class::IMPORT).to eq("import")
     end
 
     it "defines INDEX" do
       expect(described_class::INDEX).to eq("index")
     end
 
+    it "defines LINK_FIXTURE" do
+      expect(described_class::LINK_FIXTURE).to eq("link_fixture")
+    end
+
+    it "defines MEMBER_EXPORT_XLSX" do
+      expect(described_class::MEMBER_EXPORT_XLSX).to eq("member_export_xlsx")
+    end
+
+    it "defines MERGE" do
+      expect(described_class::MERGE).to eq("merge")
+    end
+
+    it "defines NEW" do
+      expect(described_class::NEW).to eq("new")
+    end
+
+    it "defines READ" do
+      expect(described_class::READ).to eq("read")
+    end
+
+    it "defines REJECT" do
+      expect(described_class::REJECT).to eq("reject")
+    end
+
+    it "defines SHARE" do
+      expect(described_class::SHARE).to eq("share")
+    end
+
     it "defines SHOW" do
       expect(described_class::SHOW).to eq("show")
+    end
+
+    it "defines UNARCHIVE" do
+      expect(described_class::UNARCHIVE).to eq("unarchive")
+    end
+
+    it "defines UPDATE" do
+      expect(described_class::UPDATE).to eq("update")
+    end
+
+    it "defines UPLOAD" do
+      expect(described_class::UPLOAD).to eq("upload")
     end
   end
 
   describe ".all" do
-    it "returns all operation values sorted alphabetically" do
-      result = described_class.all
-
-      expect(result).to include("archived", "create", "update", "deleted", "index", "show")
-      expect(result).to eq(result.sort)
+    it "returns the explicit ordered list of all operations" do
+      expect(described_class.all).to eq(
+        [
+          "archive",
+          "collection_export_xlsx",
+          "commit",
+          "copy",
+          "create",
+          "create_from_upload",
+          "destroy",
+          "disambiguate",
+          "disassociate",
+          "edit",
+          "enter_match_night",
+          "export_import_example",
+          "import",
+          "index",
+          "link_fixture",
+          "member_export_xlsx",
+          "merge",
+          "new",
+          "read",
+          "reject",
+          "share",
+          "show",
+          "unarchive",
+          "update",
+          "upload"
+        ]
+      )
     end
 
     it "returns frozen strings" do
-      expect(described_class::ARCHIVED).to be_frozen
-      expect(described_class::CREATE).to be_frozen
-      expect(described_class::UPDATE).to be_frozen
+      described_class.constants.each do |const_name|
+        expect(described_class.const_get(const_name)).to be_frozen
+      end
     end
   end
 
@@ -46,9 +147,11 @@ RSpec.describe SystemOperations do
     it "returns an array of uppercase label and lowercase value pairs" do
       options = described_class.options_for_select
 
-      expect(options).to include([ "ARCHIVED", "archived" ])
-      expect(options).to include([ "CREATE", "create" ])
-      expect(options).to include([ "UPDATE", "update" ])
+      expect(options).to include([ "ARCHIVE", "archive" ])
+      expect(options).to include([ "DESTROY", "destroy" ])
+      expect(options).to include([ "UNARCHIVE", "unarchive" ])
+      expect(options).to include([ "MERGE", "merge" ])
+      expect(options).to include([ "ENTER_MATCH_NIGHT", "enter_match_night" ])
     end
   end
 end

--- a/spec/modules/system_operations_spec.rb
+++ b/spec/modules/system_operations_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe SystemOperations do
       expect(described_class::EXPORT_IMPORT_EXAMPLE).to eq("export_import_example")
     end
 
+    it "defines IMPERSONATE" do
+      expect(described_class::IMPERSONATE).to eq("impersonate")
+    end
+
     it "defines IMPORT" do
       expect(described_class::IMPORT).to eq("import")
     end
@@ -90,6 +94,10 @@ RSpec.describe SystemOperations do
       expect(described_class::SHOW).to eq("show")
     end
 
+    it "defines TRIGGER_PASSWORD_RESET_EMAIL" do
+      expect(described_class::TRIGGER_PASSWORD_RESET_EMAIL).to eq("trigger_password_reset_email")
+    end
+
     it "defines UNARCHIVE" do
       expect(described_class::UNARCHIVE).to eq("unarchive")
     end
@@ -119,6 +127,7 @@ RSpec.describe SystemOperations do
           "edit",
           "enter_match_night",
           "export_import_example",
+          "impersonate",
           "import",
           "index",
           "link_fixture",
@@ -129,6 +138,7 @@ RSpec.describe SystemOperations do
           "reject",
           "share",
           "show",
+          "trigger_password_reset_email",
           "unarchive",
           "update",
           "upload"

--- a/spec/modules/team_match_levels_spec.rb
+++ b/spec/modules/team_match_levels_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe TeamMatchLevels do
+  describe "constants" do
+    it "defines REGULAR_SEASON" do
+      expect(described_class::REGULAR_SEASON).to eq("regular_season")
+    end
+
+    it "defines LOCAL_PLAYOFF" do
+      expect(described_class::LOCAL_PLAYOFF).to eq("local_playoff")
+    end
+
+    it "defines DISTRICT" do
+      expect(described_class::DISTRICT).to eq("district")
+    end
+
+    it "defines SECTION" do
+      expect(described_class::SECTION).to eq("section")
+    end
+
+    it "defines NATIONAL" do
+      expect(described_class::NATIONAL).to eq("national")
+    end
+
+    it "defines TOURNAMENT" do
+      expect(described_class::TOURNAMENT).to eq("tournament")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "regular_season",
+          "local_playoff",
+          "district",
+          "section",
+          "national",
+          "tournament"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::REGULAR_SEASON).to be_frozen
+      expect(described_class::LOCAL_PLAYOFF).to be_frozen
+      expect(described_class::DISTRICT).to be_frozen
+      expect(described_class::SECTION).to be_frozen
+      expect(described_class::NATIONAL).to be_frozen
+      expect(described_class::TOURNAMENT).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Regular Season", "regular_season" ],
+          [ "Local Playoff", "local_playoff" ],
+          [ "District", "district" ],
+          [ "Section", "section" ],
+          [ "National", "national" ],
+          [ "Tournament", "tournament" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/team_player_roles_spec.rb
+++ b/spec/modules/team_player_roles_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe TeamPlayerRoles do
+  describe "constants" do
+    it "defines PLAYER" do
+      expect(described_class::PLAYER).to eq("player")
+    end
+
+    it "defines CO_CAPTAIN" do
+      expect(described_class::CO_CAPTAIN).to eq("co_captain")
+    end
+
+    it "defines CAPTAIN" do
+      expect(described_class::CAPTAIN).to eq("captain")
+    end
+  end
+
+  describe ".all" do
+    it "returns all values in canonical order" do
+      expect(described_class.all).to eq(
+        [
+          "player",
+          "co_captain",
+          "captain"
+        ]
+      )
+    end
+
+    it "is frozen to prevent modification" do
+      expect(described_class::PLAYER).to be_frozen
+      expect(described_class::CO_CAPTAIN).to be_frozen
+      expect(described_class::CAPTAIN).to be_frozen
+    end
+  end
+
+  describe ".options_for_select" do
+    it "returns an array of label/value pairs for form selects" do
+      expect(described_class.options_for_select).to eq(
+        [
+          [ "Player", "player" ],
+          [ "Co Captain", "co_captain" ],
+          [ "Captain", "captain" ]
+        ]
+      )
+    end
+  end
+end

--- a/spec/support/shared_contexts/policy_setup.rb
+++ b/spec/support/shared_contexts/policy_setup.rb
@@ -12,13 +12,19 @@ RSpec.shared_context 'policy_setup' do
   let(:system_role) { create(:system_role) }
   let(:sp_archive) { create(:system_permission, name: "#{klass} Archive", resource: klass, operation: 'archive') }
   let(:sp_collection_export_xlsx) { create(:system_permission, name: "#{klass} Collection Export Xlsx", resource: klass, operation: 'collection_export_xlsx') }
+  let(:sp_commit) { create(:system_permission, name: "#{klass} Commit", resource: klass, operation: 'commit') }
   let(:sp_copy) { create(:system_permission, name: "#{klass} Copy", resource: klass, operation: 'copy') }
   let(:sp_create) { create(:system_permission, name: "#{klass} Create", resource: klass, operation: 'create') }
   let(:sp_destroy) { create(:system_permission, name: "#{klass} Destroy", resource: klass, operation: 'destroy') }
+  let(:sp_disambiguate) { create(:system_permission, name: "#{klass} Disambiguate", resource: klass, operation: 'disambiguate') }
   let(:sp_edit) { create(:system_permission, name: "#{klass} Edit", resource: klass, operation: 'edit') }
+  let(:sp_enter_match_night) { create(:system_permission, name: "#{klass} Enter Match Night", resource: klass, operation: 'enter_match_night') }
   let(:sp_index) { create(:system_permission, name: "#{klass} Index", resource: klass, operation: 'index') }
+  let(:sp_link_fixture) { create(:system_permission, name: "#{klass} Link Fixture", resource: klass, operation: 'link_fixture') }
   let(:sp_member_export_xlsx) { create(:system_permission, name: "#{klass} Member Export Xlsx", resource: klass, operation: 'member_export_xlsx') }
+  let(:sp_merge) { create(:system_permission, name: "#{klass} Merge", resource: klass, operation: 'merge') }
   let(:sp_new) { create(:system_permission, name: "#{klass} New", resource: klass, operation: 'new') }
+  let(:sp_reject) { create(:system_permission, name: "#{klass} Reject", resource: klass, operation: 'reject') }
   let(:sp_show) { create(:system_permission, name: "#{klass} Show", resource: klass, operation: 'show') }
   let(:sp_update) { create(:system_permission, name: "#{klass} Update", resource: klass, operation: 'update') }
   let(:sp_unarchive) { create(:system_permission, name: "#{klass} Unarchive", resource: klass, operation: 'unarchive') }
@@ -27,13 +33,19 @@ RSpec.shared_context 'policy_setup' do
     system_role.system_permissions << [
       sp_archive,
       sp_collection_export_xlsx,
+      sp_commit,
       sp_copy,
       sp_create,
       sp_destroy,
+      sp_disambiguate,
       sp_edit,
+      sp_enter_match_night,
       sp_index,
+      sp_link_fixture,
       sp_member_export_xlsx,
+      sp_merge,
       sp_new,
+      sp_reject,
       sp_show,
       sp_unarchive,
       sp_update

--- a/spec/support/shared_examples/archivable.rb
+++ b/spec/support/shared_examples/archivable.rb
@@ -19,6 +19,23 @@ RSpec.shared_examples 'archivable' do
     end
   end
 
+  describe '.archive!' do
+    it 'transitions an active instance to archived' do
+      instance_of_class = create(described_class.name.underscore.to_sym, archived_at: nil)
+
+      expect { instance_of_class.archive! }.to change { instance_of_class.reload.archived? }.from(false).to(true)
+      expect(instance_of_class.archived_at).to be_a(ActiveSupport::TimeWithZone).or be_a(DateTime)
+      expect(instance_of_class.active?).to be_falsey
+    end
+
+    it 'raises ActiveRecord::RecordInvalid when underlying update! fails' do
+      instance_of_class = create(described_class.name.underscore.to_sym, archived_at: nil)
+      allow(instance_of_class).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(instance_of_class))
+
+      expect { instance_of_class.archive! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   describe '.unarchive' do
     it 'unarchives the instance' do
       instance_of_class = create(described_class.name.underscore.to_sym, archived_at: DateTime.current)
@@ -26,6 +43,23 @@ RSpec.shared_examples 'archivable' do
       instance_of_class.reload
       expect(instance_of_class.archived?).to be_falsey
       expect(instance_of_class.active?).to be_truthy
+    end
+  end
+
+  describe '.unarchive!' do
+    it 'transitions an archived instance to active' do
+      instance_of_class = create(described_class.name.underscore.to_sym, archived_at: DateTime.current)
+
+      expect { instance_of_class.unarchive! }.to change { instance_of_class.reload.active? }.from(false).to(true)
+      expect(instance_of_class.archived_at).to be_nil
+      expect(instance_of_class.archived?).to be_falsey
+    end
+
+    it 'raises ActiveRecord::RecordInvalid when underlying update! fails' do
+      instance_of_class = create(described_class.name.underscore.to_sym, archived_at: DateTime.current)
+      allow(instance_of_class).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(instance_of_class))
+
+      expect { instance_of_class.unarchive! }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 


### PR DESCRIPTION
## Summary

Phase 1A foundation work for the Baseline data model: template contract fixes inherited from Optimus, 21 enum modules with full spec coverage, and SystemOperations canonicalization that brings the constants module into alignment with the runtime authorization vocabulary.

Closes #22.

## Changes

### Template contract fixes
- `Archivable` concern adds `archive!` / `unarchive!` bang methods (wrap `update!`). `AdminController#destroy/#archive/#unarchive` already call these — they would have raised `NoMethodError` at runtime.
- `AdminController#destroy:14` typo fixed: `action_nameD` → `action_name`.

### SystemOperations canonicalization (action-name vocabulary) — 27 operations total
- Renamed `ARCHIVED` → `ARCHIVE`, `DELETED` → `DESTROY`, `UNARCHIVED` → `UNARCHIVE` (constants and string values both shift to action-name vocabulary).
- Appended 6 Baseline custom ops: `COMMIT`, `DISAMBIGUATE`, `ENTER_MATCH_NIGHT`, `LINK_FIXTURE`, `MERGE`, `REJECT`.
- Added 2 missing routed/policy operations (caught during Codex P1 review): `IMPERSONATE`, `TRIGGER_PASSWORD_RESET_EMAIL`.
- `SystemPermissionsBulkCreateTask` is now functional (the action-name constants it references now resolve; no change to the task itself).
- Spec asserts the explicit ordered list of 27 operations.

### Seed file alignment (caught during Codex P1 review)
- Privatized `controller_class`, `controller_class_plural`, `controller_class_singular`, `controller_class_symbolized` in `ApplicationController`. Previously public, they leaked into `controller.action_methods` and would be seeded as bogus `SystemPermission` rows for every Admin resource. Verified via grep that they are only called from within controller subclasses (no view, component, or helper references), so private visibility is sufficient.

### 21 enum modules + specs
Modules in `app/modules/` (canonical values from #2): `AgeLevels`, `GenderTypes`, `PlayerGenders`, `GameFormatTypes`, `TeamPlayerRoles`, `RatingSystems`, `RatingTypes`, `GradeStatuses`, `GradeRationales`, `GradeSources`, `AliasSources`, `ScheduledFixtureStatuses`, `TeamMatchLevels`, `MatchFormats`, `MatchRulesFormats`, `MatchOutcomes`, `MatchSides`, `H2HFormats`, `ImportKinds`, `ImportSourceTypes`, `ImportStatuses`. Each follows the `NotificationDistributionMethods` pattern (frozen constants, `.all`, `.options_for_select`).

Each spec asserts: literal constant values, `.all` ordered list, frozen invariants, and explicit `options_for_select` arrays.

### `H2H` inflection
Added `inflect.acronym "H2H"` to `config/initializers/inflections.rb` so Zeitwerk maps `app/modules/h2h_formats.rb` ↔ `H2HFormats`.

### `Has*` enum concerns intentionally NOT created
Original plan included 22 `Has*` concerns. HC decision (per Codex review) was to drop them — Phases 1B–1E will validate enums directly with `inclusion: { in: <Module>.all }` on consuming models. Removes ~44 ceremonial files.

### `policy_setup` shared context
Added 6 new `sp_*` lets in lexical order: `sp_commit`, `sp_disambiguate`, `sp_enter_match_night`, `sp_link_fixture`, `sp_merge`, `sp_reject`.

### `Archivable` spec coverage
- `spec/support/shared_examples/archivable.rb` extended with real active→archived / archived→active transitions and bang-method failure assertions.
- `spec/models/concerns/archivable_spec.rb` (new) exercises bang methods directly against `User`.

## Technical Approach

The driving question across all four plan revisions was where the SystemOperations vocabulary should land. Investigation surfaced:

| Layer | Vocabulary | Source |
|---|---|---|
| `db/seeds/system_permissions.rb` | action names | `controller.action_methods` → `"archive"`, `"destroy"`, `"unarchive"` |
| `AdminApplicationPolicy` | action names | `user_access_authorized?(:archive)` etc. |
| `User#access_authorized?` | action names | queries `SystemPermission.where(operation: "archive")` |
| `policy_setup` test fixtures | action names | `operation: 'archive'` |
| `SystemOperations` constants (before) | past-tense | `ARCHIVED = "archived"` |
| `SystemPermissionsBulkCreateTask` (broken) | action names | references constants that didn't exist |

The auth flow is action-name end-to-end. The past-tense `SystemOperations` constants were vestigial — referenced nowhere in the auth path. This PR aligns the constants to action-name vocabulary, which makes the previously-broken `SystemPermissionsBulkCreateTask` functional and ends the internal-Optimus drift.

The Codex P1 review (commit 3f608f5) extended the audit to two additional drift sources: missing constants for routed policy operations (`trigger_password_reset_email`, `impersonate`), and seed-file leakage of inherited `ApplicationController` helper methods.

No data migration is required: existing seed data is generated from `controller.action_methods` (already action-name format), so seeded `SystemPermission` rows are already in the correct vocabulary.

## Testing

- `bundle exec rubocop -a` — 292 files, 0 offenses
- `bundle exec rspec` — **878 examples, 0 failures**
- `bin/brakeman --no-pager -q` — 0 errors, 0 security warnings
- `bin/bundler-audit check` — no vulnerabilities

Test additions:
- 21 module specs (literal value + `.all` order + frozen + `options_for_select`)
- Expanded `system_operations_spec.rb` (27-op explicit list, all 27 constants asserted)
- Expanded `archivable` shared example (bang transitions + failure modes)
- New `archivable_spec.rb` concern spec exercising bang methods against User

## Checklist

- [x] All four pre-commit gates pass
- [x] Existing `it_behaves_like "archivable"` users (e.g., `User`) continue to pass
- [x] No models touched (Phase 1B–1E will land models)
- [x] No migrations (Phase 1A is pure Ruby)
- [x] No authorization logic changed in production code (additive `policy_setup` test fixtures only)
- [x] Self-review per `.claude/rules/self-review.md` complete

## Out of Scope

- Database migrations (Phases 1B–1E)
- Model classes (Phases 1B–1E)
- Pundit policy changes (Phase 4)
- New `SystemPermission` rows for the 6 custom ops (seeded in #26 — Phase 1E)
- `Notifiable` shared example (existing `spec/models/concerns/notifiable_spec.rb` covers the concern directly)

— Claude Code (Opus 4.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)